### PR TITLE
[Normalize] Fixing issue regard SSH URL with no password

### DIFF
--- a/lib/normalize.ex
+++ b/lib/normalize.ex
@@ -40,12 +40,15 @@ defmodule RFC3986.Normalize do
     userinfo state, state.userinfo, []
   end
 
-  defp userinfo(state, [?:|rest], acc) do
-    %{state | username: Enum.reverse(acc), password: rest}
-  end
-
   defp userinfo(state, [char|rest], acc) do
-    userinfo state, rest, [char|acc]
+    if char == ?: || Enum.empty?(rest) do
+      if char !== ?:, do: acc = [char|acc]
+      if Enum.empty?(rest), do: rest = nil
+
+      %{state | username: Enum.reverse(acc), password: rest}
+    else
+      userinfo(state, rest, [char|acc])
+    end
   end
 
   defp query_string(state = %{query: nil}) do

--- a/test/ex_rfc3986_test.exs
+++ b/test/ex_rfc3986_test.exs
@@ -233,6 +233,46 @@ defmodule RFC3986Test do
     )
   end
 
+  test "ssh without pass" do
+    assert_uri(
+      'ssh://user@elixir-lang.org:8812/docs/stable/elixir/Enum.html?k1?%2A=v1&k2=v2&k3&k4#fragment/other_fragment%2F??',
+      %{
+        scheme: 'ssh',
+        host_type: :reg_name,
+        host: 'elixir-lang.org',
+        port: 8812,
+        segments: ['docs', 'stable', 'elixir', 'Enum.html'],
+        query_string: %{'k1?%2A' => 'v1', 'k2' => 'v2', 'k3' => nil, 'k4' => nil},
+        fragment: 'fragment/other_fragment%2F??',
+        userinfo: 'user',
+        username: 'user',
+        password: nil,
+        query: 'k1?%2A=v1&k2=v2&k3&k4',
+        type: :authority
+      }
+    )
+  end
+
+  test "ssh with pass" do
+    assert_uri(
+      'ssh://user:pass@elixir-lang.org:8812/docs/stable/elixir/Enum.html?k1?%2A=v1&k2=v2&k3&k4#fragment/other_fragment%2F??',
+      %{
+        scheme: 'ssh',
+        host_type: :reg_name,
+        host: 'elixir-lang.org',
+        port: 8812,
+        segments: ['docs', 'stable', 'elixir', 'Enum.html'],
+        query_string: %{'k1?%2A' => 'v1', 'k2' => 'v2', 'k3' => nil, 'k4' => nil},
+        fragment: 'fragment/other_fragment%2F??',
+        userinfo: 'user:pass',
+        username: 'user',
+        password: 'pass',
+        query: 'k1?%2A=v1&k2=v2&k3&k4',
+        type: :authority
+      }
+    )
+  end
+
   defp assert_uri(uri, props) do
     Logger.debug "Testing: #{inspect uri}"
     {uri, '', result} = RFC3986.parse uri


### PR DESCRIPTION
This PR fixes the issue on `Normalize` when handling a SSH URL with no password in it.

e.g.:

``` elixir
# This works
{_, _, result} = RFC3986.parse 'ssh://user:pass@elixir-lang.org:8812/docs/stable/elixir/Enum.html?k1?%2A=v1&k2=v2&k3&k4#fragment/other_fragment%2F??'

# This doesn't
{_, _, result} = RFC3986.parse 'ssh://user@elixir-lang.org:8812/docs/stable/elixir/Enum.html?k1?%2A=v1&k2=v2&k3&k4#fragment/other_fragment%2F??'
```
